### PR TITLE
Add categories, fix some papercuts

### DIFF
--- a/inventory/static/main.css
+++ b/inventory/static/main.css
@@ -1,6 +1,6 @@
 .filter-sidebar{
   float: left;
-  padding-top: 80px;
+  padding-top: 120px;
   padding-left: 70px;
 }
 
@@ -119,11 +119,21 @@ h5{
     margin: 2.5px;
 }
 
-.left{
+.category-select{
+    display: none;
+}
+.category-select input{
+    display:block;
+}
+.category-select input:hover{
+    background-color: darkgrey;
+}
+
+.right{
     float: right;
     width: 50%;
 }
-.right{
+.left{
     float: left;
     width: 50%;
 }

--- a/inventory/static/main.js
+++ b/inventory/static/main.js
@@ -1,43 +1,41 @@
+// Enable the Chosen plugin
 function enable_advanced(items){
     options_id = "extra-options-create";
     url_id     = "advanced-items-toggle-create";
-    vendor_name = "Vendor Name";
-    vendor_url = "https://examplevendor.com";
-    purchase_cost = "Cost to Buy";
-    sale_price = "Price to Sell"
-
-    can_update = true;
-    for (i=0; i < items.length; i++){
-        if (items[i] == ""){
-            can_update = false;
-
-        }
+    dict = {
+        "vendor_name": "Vendor Name",
+        "vendor_url": "https://examplevendor.com",
+        "purchase_cost": "Cost to Buy",
+        "sale_price": "Price to Sell"
     }
+
     if (items != "create"){
         options_id = "extra-options-"+items[0];
         url_id = "advanced-items-toggle-" + items[0];
-    }
-    if (items != "create" && can_update){
-        vendor_name = items[1];
-        vendor_url = items[2];
-        purchase_cost = items[3];
-        sale_price = items[4];
+
+        list = ["vendor_name", "vendor_url", "purchase_cost", "sale_price"]
+        for (i=1; i<items.length; i++){
+            if (items[i] != ""){
+                dict[list[i-1]] = items[i]
+            }
+        }
     }
 
-    chunk = "<table>" +
+    chunk = "<input name='advanced' value='True' hidden>" +
+            "<table>" +
             "<tr>" +
-            "<td>Vendor:</td><td><input name='vendor' placeholder="+ vendor_name +" autocomplete='off'></td>" +
+            "<td>Vendor:</td><td><input name='vendor' placeholder="+ dict["vendor_name"] +" autocomplete='off'></td>" +
             "</tr><tr>" +
-            "<td>Reorder from:</td><td><input name='vendor_url' placeholder="+ vendor_url +" autocomplete='off'></td>" +
+            "<td>Reorder from:</td><td><input name='vendor_url' placeholder="+ dict["vendor_url"] +" autocomplete='off'></td>" +
             "</tr><tr>" +
-            "<td>Purchase Cost:</td><td><input name='purchase_cost' placeholder="+ purchase_cost+" autocomplete='off'></td>" +
+            "<td>Purchase Cost:</td><td><input name='purchase_cost' placeholder="+ dict["purchase_cost"]+" autocomplete='off'></td>" +
             "</tr><tr>" +
-            "<td>Sale Price:</td><td><input name='sale_price' placeholder="+ sale_price +" autocomplete='off'></td>" +
+            "<td>Sale Price:</td><td><input name='sale_price' placeholder="+ dict["sale_price"] +" autocomplete='off'></td>" +
             "</tr>" +
             "</table>"
 
-        window.localStorage.setItem("previous-href", document.getElementById(url_id).href)
-        window.localStorage.setItem("type", items[0])
+        window.localStorage.setItem("previous-href", document.getElementById(url_id).href);
+        window.localStorage.setItem("type", items[0]);
 
         document.getElementById(options_id).innerHTML = chunk;
         document.getElementById(url_id).innerText = "Advanced Items ▲";
@@ -45,7 +43,7 @@ function enable_advanced(items){
 }
 function disable_advanced(){
         prev_href = window.localStorage.getItem("previous-href");
-        prev_id = window.localStorage.getItem("type")
+        prev_id = window.localStorage.getItem("type");
         options_id = "extra-options-create";
         url_id     = "advanced-items-toggle-create";
         if (prev_id != "c"){
@@ -53,7 +51,7 @@ function disable_advanced(){
             url_id = "advanced-items-toggle-" + prev_id;
         }
 
-        document.getElementById(options_id).innerHTML = "";
+        document.getElementById(options_id).innerHTML = "<input name='advanced' value='False' hidden>";
         document.getElementById(url_id).innerText = "Advanced Items ▼";
         document.getElementById(url_id).href = prev_href;
 }

--- a/inventory/templates/base-template.jinja
+++ b/inventory/templates/base-template.jinja
@@ -2,15 +2,19 @@
 <html>
     <head>
         <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>{{ title }} - Inventory Management</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap-select.min.css') }}">
         <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
         <link rel="icon" href="{{ url_for('static', filename='site_icon.png') }}" class="js-favicon">
         <link rel="preload" href="{{url_for('static', filename='reordered.png')}}" as="image" type="image/png" />
         <!--div>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div-->
-        <script src="{{ url_for('static', filename='main.js') }}"></script>
         <script src="{{ url_for('static', filename='jquery-3.3.1.slim.min.js') }}"></script>
         <script src="{{ url_for('static', filename='bootstrap.min.js') }}"></script>
+        <script src="{{ url_for('static', filename='popper.min.js') }}"></script> <!-- Adding these for hopeful future use -->
+        <script src="{{ url_for('static', filename='bootstrap-select.min.js') }}"></script>
+        <script src="{{ url_for('static', filename='main.js') }}"></script>
         <style lang="css">
             .slide-container { width: 100%; }
             .slider {

--- a/inventory/templates/index.jinja
+++ b/inventory/templates/index.jinja
@@ -2,26 +2,36 @@
 {% block content %}
     <div class="sidebar filter-sidebar" align="left">
         <form action="{{url_for('quick_change', type='upc_search')}}" method="POST">
-            <input name="quick-take-bar" type="search" placeholder="Scan UPC Here" autofocus>
+            <input name="quick-take-bar" type="search" placeholder="Scan UPC Here" required autofocus autocomplete="off">
             <input type="button" type="submit" accesskey="Enter" hidden>
         </form>
         <span class="needs-space"/>
         <h4>Filters</h4>
-        <form action="{{url_for('set_filter')}}" method="POST">
-            <select name="location-filter" class="selectpicker">
-            {% if location_selected == 1 %}
-                <option value="{{ filtered_loc_id }}">{{ filtered_loc_name }}</option>
+        <form action="{{url_for('quick_filter', type='loc_cat', page='home')}}" method="POST">
+            <select name="location-filter">
+            {% if extras["loc_filter"] == 1 %}
+                <option value="{{ extras['filtered_loc_id'] }}">{{ extras['filtered_loc_name'] }}</option>
             {% endif %}
                 <option value="0">All Products</option>
             {% for loc_id, loc_name in locations %}
-                {% if loc_id != filtered_loc_id %}
+                {% if loc_name != extras['filtered_loc_name'] %}
                 <option value="{{loc_id}}">{{loc_name}}</option>
                 {% endif %}
             {% endfor %}
-            </select>
-            <input name="category-filter" value="" hidden/>
-            <button type="submit" class="btn btn-success">Filter</button>
-        </form>
+            </select><br>
+        <select name="category-filter">
+            {% if extras["cat_filter"] == 1 %}
+                <option value="{{ extras['filtered_cat_id']}}">{{ extras['filtered_cat_name']}}</option>
+            {% endif %}
+            <option value="0">All Categories</option>
+            {% for cat_id, cat_name in categories %}
+                {% if cat_name != extras['filtered_cat_name'] %}
+                    <option value="{{ cat_id }}">{{ cat_name }}</option>
+                {% endif %}
+            {% endfor %}
+        </select>
+    <button type="submit" class="btn btn-success">filter</button>
+    </form>
     </div>
     <div class="container" style="float: contour;" align="center">
     <h3 align="center">Inventory</h3>
@@ -44,8 +54,8 @@
                 {% set quick_take_qty = product[4]|int %}
                 {% set min_qty        = product[5]|int %}
                 {% set reorder_qty    = product[6]|int %}
-                {% set location       = product[7] %}
-                {% set categories     = product[8] %}
+                {% set prod_loc       = product[7] %}
+                {% set prod_cat       = product[8] %}
                 {% set been_reordered = product[9]|int %}
 
                 {% if prod_qty >= min_qty %}
@@ -163,8 +173,6 @@
                         </div>
                     </div>
                 </div>
-
-
                 </div>
         {% endfor %}
         </div>

--- a/inventory/templates/location.jinja
+++ b/inventory/templates/location.jinja
@@ -3,25 +3,27 @@
 <div class="container">
     <h3 align="center">Location</h3>
     <table class="table">
-        <thead><th scope="col">Location ID</th><th scope="col">Location Name</th><th></th><th></th></thead>
+        <thead><th scope="col">Location ID</th><th scope="col">Location Name</th><th>Items in Location</th><th></th><th></th></thead>
         <tbody>
-            {% for location in warehouses %}
+            {% for loc_id, loc_name in warehouses %}
+
+                {% set unhooked_id = warehouses.index((loc_id, loc_name))+1 %}
             <tr>
-                <td>{{ location[0] }}</td><td>{{ location[1] }}</td>
+                <td>{{ unhooked_id }}</td><td>{{ loc_name }}</td><td>{{ prod_amt[loc_id] }} items</td>
                 <td>
-                    <a href="{{ url_for('delete', loc_id=location[0], type='location') }}">
+                    <a href="{{ url_for('delete', loc_id=loc_id, type='location') }}">
                         <button name="button" type="button" class="btn btn-danger" value="delete">delete</button><br>
                     </a>
                 </td>
                 <td>
-                    <button name="button" type="button" class="btn btn-success" value="edit" data-toggle="modal" data-target="#edit_{{ location[0] }}">edit</button><br>
-                    <div id="edit_{{ location[0] }}" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="trans_message" aria-hidden="true">
+                    <button name="button" type="button" class="btn btn-success" value="edit" data-toggle="modal" data-target="#edit_{{ loc_id }}">edit</button><br>
+                    <div id="edit_{{ loc_id }}" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="trans_message" aria-hidden="true">
                     <form action="{{ url_for('edit', type='location') }}" method="post">
                         <div class="modal-dialog" role="document">
                             <div class="modal-content">
-                                <div class="modal-body"><input name="loc_name" placeholder="{{ location[1] }}"></div>
+                                <div class="modal-body"><input name="loc_name" placeholder="{{ loc_name }}"></div>
                                 <div class="modal-footer">
-                                    <input name="loc_id" value="{{ location[0] }}" hidden aria-hidden="true">
+                                    <input name="loc_id" value="{{ loc_id }}" hidden aria-hidden="true">
                                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                                     <button type="submit" class="btn btn-primary">Save changes</button>
                                 </div>
@@ -36,7 +38,7 @@
             <tr>
                 <form action="{{ url_for('location') }}" method="POST">
                     <td></td>
-                    <td><input name="warehouse_name" placeholder="Warehouse Name" required autofocus></td>
+                    <td><input name="warehouse_name" placeholder="Location Name" required autofocus autocomplete="off"></td>
                     <td><input type="submit" class="btn btn-info btn-group-toggle" value="submit" /><br></td>
                 </form>
             </tr>

--- a/inventory/templates/product.jinja
+++ b/inventory/templates/product.jinja
@@ -1,10 +1,43 @@
 {% extends 'base-template.jinja' %}
 {% block content %}
+<div class="sidebar filter-sidebar">
+    <form action="{{url_for('quick_filter', type='upc_search', page='product')}}" method="POST">
+        <input name="quick-search-bar" type="search" placeholder="Scan UPC Here" required autofocus autocomplete="off">
+        <input type="button" type="submit" accesskey="Enter" hidden>
+    </form>
+    <span class="needs-space"/>
+    <h4>Filters</h4>
+    <form action="{{url_for('quick_filter', type='loc_cat', page='product')}}" method="POST">
+        <select name="location-filter">
+        {% if extras["loc_filter"] == 1 %}
+            <option value="{{ extras['filtered_loc_id'] }}">{{ extras['filtered_loc_name'] }}</option>
+        {% endif %}
+            <option value="0">All Products</option>
+        {% for loc_id, loc_name in locations %}
+            {% if loc_name != extras['filtered_loc_name'] %}
+            <option value="{{loc_id}}">{{loc_name}}</option>
+            {% endif %}
+        {% endfor %}
+        </select><br>
+        <select name="category-filter">
+            {% if extras["cat_filter"] == 1 %}
+                <option value="{{ extras['filtered_cat_id']}}">{{ extras['filtered_cat_name']}}</option>
+            {% endif %}
+            <option value="0">All Categories</option>
+            {% for cat_id, cat_name in categories %}
+                {% if cat_name != extras['filtered_cat_name'] %}
+                    <option value="{{ cat_id }}">{{ cat_name }}</option>
+                {% endif %}
+            {% endfor %}
+        </select>
+        <button type="submit" class="btn btn-success">filter</button>
+    </form>
+</div>
 <div class="container">
     <h3 align="center">Inventory</h3>
     <hr>
     <div name="create-button" style="float: inline-right;" align="right">
-        <button class="btn btn-success" value="create" data-toggle="modal" data-target="#create">Add New</button>
+        <button class="btn btn-success" value="create" data-toggle="modal" data-target="#create">add new</button>
     </div>
         <div id="create" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="trans_message" aria-hidden="true">
             <form action = "{{ url_for('product') }}" method = "POST">
@@ -38,12 +71,11 @@
                                 <td>Location:<span class="required">*</span></td><td>
                                 <select name="location" required>
                                 {% if not locations %}
-                                    <option value="">No locations available</option>
+                                    <option>No locations available</option>
                                 {% else %}
-                                {% for location in locations %}
-                                        {% set location_id = location[0] %}
-                                        {%set location_name = location[1] %}
-                                        <option value="{{ location_id }}">{{location_name}}</option>
+                                    <option>Please select a location</option>
+                                {% for loc_id, loc_name in locations %}
+                                    <option value="{{ loc_id }}">{{loc_name}}</option>
                                 {% endfor %}
                                 {% endif %}
                                 </select></td>
@@ -52,12 +84,14 @@
                                 <td> Categories:</td><td>
                                 <select name="categories">
                                 {% if not categories %}
-                                    <option value="">No categories available</option>
+                                    <option>No categories available</option>
                                     <!-- https://www.geeksforgeeks.org/how-to-use-checkbox-inside-select-option-using-javascript/ -->
+                                    <!-- https://getbootstrap.com/docs/4.0/components/dropdowns/ -->
                                 {% else %}
-                                {% for category in categories %}
-                                    <option value="{{ category[0] }}"> {{ category[1] }}</option>
-                                {% endfor %}
+                                    <option>No category selected</option>
+                                    {% for cat_id, cat_name in categories %}
+                                        <option value="{{ cat_id }}"> {{ cat_name }}</option>
+                                    {% endfor %}
                                 {% endif %}}
                                 </select></td>
                             </tr>
@@ -65,7 +99,9 @@
                         <a href="javascript:enable_advanced('create')" id="advanced-items-toggle-create">Advanced Items ▼</a>
 
                         </div>
-                        <div id="extra-options-create" class="modal-body"></div>
+                        <div id="extra-options-create" class="modal-body">
+                            <input name='advanced' value='False' hidden>
+                        </div>
                         <div class="modal-footer">
                             <span id="modal-disclaimer">Items marked with asterisk (<span class="required">*</span>) are required</span>
                             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -96,8 +132,8 @@
                 {% set quick_take_qty = product[4]|int %}
                 {% set min_qty        = product[5]|int %}
                 {% set restock_qty    = product[6]|int %}
-                {% set location       = product[7] %}
-                {% set categories     = product[8] %}
+                {% set prod_loc       = product[7]|int %}
+                {% set prod_cat       = product[8] %}
                 {% set been_reordered = product[9]|int %}
                 {% set vendor         = product[10] %}
                 {% set vendor_url     = product[11] %}
@@ -105,6 +141,11 @@
                 {% set sale_price     = product[13] %}
 
                 {# Data Validation -- pretty sure this can/should be done server-side #}
+                {% if not prod_cat %}
+                    {% set prod_cat = "" %}
+                {% else %}
+                    {% set prod_cat = prod_cat|int %}
+                {% endif %}
                 {% if not vendor %}
                     {% set vendor = "" %}
                 {% endif %}
@@ -129,13 +170,27 @@
                         {% set tickbox_state = "checked" %}
                     {% else %}
                         {% set need_reordered = "Yes" %}
-                        {% set tickbox_state = "unchecked" %}
+                        {% set tickbox_state = "" %}
+                    {% endif %}
+                {% endif %}
+
+                {% if prod_qty < min_qty %}
+                    {% if prod_qty == 0 %}
+                        {% set state="out" %}
+                    {% elif prod_qty <= (min_qty/2) %}
+                        {% set state="warning" %}
+                    {% else %}
+                        {% set state="low" %}
                     {% endif %}
                 {% endif %}
 
                 {% set unhooked_id = products.index(product)+1 %}
-                <tr>
-                    <td>{{ unhooked_id }}</td><td>{{ prod_name }}</td><td>{{ prod_qty }}</td><td>{{ min_qty }}</td><td>{{ need_reordered }}</td>
+                <tr class="{{ state }} product-row">
+                    <td>{{ unhooked_id }}</td>
+                    <td>{{ prod_name }}</td>
+                    <td>{{ prod_qty }}</td>
+                    <td>{{ min_qty }}</td>
+                    <td>{{ need_reordered }}</td>
                     <td>
                         <a href="{{ url_for('delete', prod_id=prod_id, type='product') }}">
                             <button name="button" type="button" class="btn btn-danger" value="delete" >delete</button><br>
@@ -179,34 +234,52 @@
                                             <td>Location:</td><td>
                                             <select name="location">
                                             {% if not locations %}
-                                                <option value="">No locations available</option>
+                                                <option>No locations available</option>
                                             {% else %}
-                                            {% for location in locations %}
-                                                    {% set location_id = location[0] %}
-                                                    {%set location_name = location[1] %}
-                                                    <option value="{{ location_id }}">{{location_name}}</option>
-                                            {% endfor %}
+                                                {% for loc_id, loc_name in locations %}
+                                                    {% if prod_loc|int == loc_id %}
+                                                        <option value="{{ loc_id }}">{{ loc_name }}</option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                                {% for loc_id, loc_name in locations %}
+                                                    {% if loc_id|int != prod_loc %}
+                                                        <option value="{{ loc_id }}">{{loc_name}}</option>
+                                                    {% endif %}
+                                                {% endfor %}
                                             {% endif %}
                                             </select></td>
                                         </tr>
                                         <tr>
                                             <td> Categories:</td><td>
-                                            <select name="categories">
+                                            <select name="categories" >
                                             {% if not categories %}
-                                                <option value="">No categories available</option>
+                                                <option>No categories available</option>
                                                 <!-- https://www.geeksforgeeks.org/how-to-use-checkbox-inside-select-option-using-javascript/ -->
                                             {% else %}
-                                                {% for category in categories %}
-                                                    <option value="{{ category[0] }}"> {{ category[1] }}</option>
+                                                {% if prod_cat != 0 %}
+                                                    {% for cat_id, cat_name in categories %}
+                                                        {% if cat_id|int == prod_cat %}
+                                                            <option value="{{ cat_id }}">{{ cat_name }}</option>
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                {% else %}
+                                                    <option>No category selected</option>
+                                                {% endif %}
+                                                {% for cat_id, cat_name in categories %}
+                                                    {% if cat_id|int != prod_cat %}
+                                                        <option value="{{ cat_id }}">{{ cat_name }}</option>
+                                                    {% endif %}
                                                 {% endfor %}
-                                            {% endif %}}
+                                            {% endif %}
                                             </select></td>
                                         </tr>
                                         </table>
                                         <a href="javascript:enable_advanced({{ [prod_id, vendor, vendor_url, purchase_cost, sale_price] }})" id="advanced-items-toggle-{{ prod_id }}">Advanced Items ▼</a>
 
                         </div>
-                        <div id="extra-options-{{prod_id}}" class="modal-body"></div>
+                        <div id="extra-options-{{prod_id}}" class="modal-body">
+                            <input name='advanced' value='False' hidden>
+                        </div>
                                     <div class="modal-footer">
                                         <input name="prod_id" value="{{ prod_id }}" hidden aria-hidden="true">
                                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -214,6 +287,8 @@
                                     </div>
                                 </div>
                             </div>
+                            <script>
+                            </script>
                             </div>
                             </form>
                         </div>

--- a/inventory/templates/settings.jinja
+++ b/inventory/templates/settings.jinja
@@ -25,7 +25,7 @@
         </table>
         <form action="{{ url_for('categories') }}" method="POST">
             <input name="new_category" style="width: 175px;" class="needs-space">
-            <button class="btn btn-primary" type="submit">Add New</button>
+            <button class="btn btn-primary" type="submit">add new</button>
         </form>
     </div>
 
@@ -33,7 +33,7 @@
         <h5>Default Location Filter:</h5>
         <p>Filter items on Home page by default.</p>
             <form action="{{url_for('set_filter')}}" method="POST">
-                <select name="location-filter" class="selectpicker">
+                <select name="location-filter">
                 {% if location_selected == 1 %}
                     <option value="{{ filtered_loc_id }}">{{ filtered_loc_name }}</option>
                 {% endif %}
@@ -45,7 +45,7 @@
                 {% endfor %}
                 </select>
                 <input name="category-filter" value="" hidden/>
-                <button type="submit" class="btn btn-success">Filter</button>
+                <button type="submit" class="btn btn-success">filter</button>
             </form>
         </div>
 </div>


### PR DESCRIPTION
- Add categories to close #7
- Add a "return_args" dictionary for page arguments that may not always be present
- Allow for Vendor, Vendor URL, Purchase Cost, and Sale Price fields to be tracked
- Modified most calls to the `products` table to sort alphabetically by default
- Add a "Number in Location" field on the Locations page to Close #21
- Added handling for unknown UPCs to close #28
- Added quick_filter to close #29
- Products that are low also have color on the Products page
- Changed grammar on some buttons for consistency